### PR TITLE
fix: order name and storage correctly when logging initial load failures

### DIFF
--- a/src/persistent.rs
+++ b/src/persistent.rs
@@ -76,8 +76,8 @@ impl<R: Resource + Serialize + DeserializeOwned> Persistent<R> {
             } else {
                 log::warn!(
                     "failed to load {} from {} due to a deserialization error",
-                    storage,
                     name,
+                    storage,
                 );
             }
             error


### PR DESCRIPTION
(introduced by https://github.com/umut-sahin/bevy-persistent/commit/871e655bf95131d50c7b36d4239a09d4265b7152)