### PR TITLE
Disable unused bevy's features to make it more compatible

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ license = "MIT OR Apache-2.0"
 authors = [
     "Umut Şahin <umutsahin@protonmail.com>",
     "Shane Lillie <ignignokterr@gmail.com>",
+    "Eri Pazos <eri@inventati.org>",
 ]
 
 [dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ authors = [
 ]
 
 [dependencies]
-bevy = { version = "0.12", features = ["serialize"] }
+bevy = { version = "0.12", default-features = false, features = ["serialize"] }
 bincode = { version = "1.3", optional = true }
 ron = { version = "0.8", optional = true }
 serde = { version = "1.0" }
@@ -29,6 +29,7 @@ gloo-storage = { version = "0.3" }
 [dev-dependencies]
 anyhow = { version = "1.0" }
 dirs = { version = "5.0" }
+bevy = { version = "0.12", features = ["serialize"] }
 
 [target.'cfg(not(target_family = "wasm"))'.dev-dependencies]
 tempfile = { version = "3.4" }


### PR DESCRIPTION
This is a very minor change, it adds `default-features = false` on the bevy dependency so that you can use it with other plugins that need to disable one of them (for example, [bevy_kira_audio](https://github.com/NiklasEi/bevy_kira_audio)). It seems like the only feature used on the library is `serialize`. As the examples use `bevy_sprite`, I added bevy to `dev-dependencies` with `default-features` enabled, since this doesn't conflict with other plugins. I hope everything is ok! I tested it and it seems to be working.