### PR TITLE
Fix revert_to_default_in_memory

### DIFF
--- a/src/persistent.rs
+++ b/src/persistent.rs
@@ -166,7 +166,6 @@ impl<R: Resource + Serialize + DeserializeOwned> Persistent<R> {
                             return Err(error);
                         }
                         if loaded && result.revert_to_default_in_memory().is_err() {
-                            log::error!("failed to revert {} to default in memory", result.name);
                             // return the original deserialization error
                             return Err(error);
                         }

--- a/src/persistent.rs
+++ b/src/persistent.rs
@@ -409,13 +409,14 @@ impl<R: Resource + Serialize + DeserializeOwned> Persistent<R> {
         // this is because cloning can have special semantics
         // e.g., cloning Persistent<Arc<RwLock<R>>> and changing it
         // would change the default object, which is not desired
-        let serialized = self.format.serialize(&self.name, &self.default).map_err(|error| {
-            log::error!(
-                "failed to revert {} to default in memory due to a serialization error",
-                self.name,
-            );
-            error
-        })?;
+        let serialized =
+            self.format.serialize(&self.name, self.default.as_ref().unwrap()).map_err(|error| {
+                log::error!(
+                    "failed to revert {} to default in memory due to a serialization error",
+                    self.name,
+                );
+                error
+            })?;
         let reconstructed = self.format.deserialize(&self.name, &serialized).map_err(|error| {
             log::error!(
                 "failed to revert {} to default in memory due to a deserialization error",


### PR DESCRIPTION
I tried out the revert on deserialization error feature, but it doesn't handle reverting in memory completely resulting in the builder returning `None`.

The problem appears to be that `default` is being serialized as `Option<R>` instead of `R`, so deserialization fails with something like the following:

```
2024-01-10T09:22:01.462719Z ERROR bevy_persistent::format: failed to parse settings as pretty RON

1:5: Expected struct `Settings` but found `Some`
2024-01-10T09:22:01.462724Z ERROR bevy_persistent::persistent: failed to revert settings to default in memory due to a deserialization error
2024-01-10T09:22:01.462725Z ERROR bevy_persistent::persistent: failed to revert settings to default in memory
```

Also removed the last log statement since it seems redundant.