### PR TITLE
Update to Bevy 0.16

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,6 @@ Cargo.lock
 
 # Visual Studio Code
 .vscode
+
+# From running within this directory
+/local

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ authors = [
 ]
 
 [dependencies]
-bevy = { version = "0.15", default-features = false }
+bevy = { version = "0.16", default-features = false, features = ["std", "bevy_log"] }
 bincode = { version = "1.3", optional = true }
 ron = { version = "0.8", optional = true }
 serde = { version = "1.0" }
@@ -33,7 +33,8 @@ gloo-storage = { version = "0.3" }
 [dev-dependencies]
 anyhow = { version = "1.0" }
 dirs = { version = "5.0" }
-bevy = { version = "0.15", features = ["serialize"] }
+bevy = { version = "0.16", features = ["serialize", "std", "bevy_log"] }
+
 
 [target.'cfg(not(target_family = "wasm"))'.dev-dependencies]
 tempfile = { version = "3.4" }

--- a/examples/smart-window.rs
+++ b/examples/smart-window.rs
@@ -58,21 +58,21 @@ fn main() {
 
 fn on_window_moved(
     events: EventReader<WindowMoved>,
-    windows: Query<&Window>,
+    windows: Single<&Window>,
     window_state: ResMut<Persistent<WindowState>>,
 ) {
     if !events.is_empty() {
-        update_window_state(window_state, windows.single());
+        update_window_state(window_state, &windows);
     }
 }
 
 fn on_window_resized(
     events: EventReader<WindowResized>,
-    windows: Query<&Window>,
+    windows: Single<&Window>,
     window_state: ResMut<Persistent<WindowState>>,
 ) {
     if !events.is_empty() {
-        update_window_state(window_state, windows.single());
+        update_window_state(window_state, &windows);
     }
 }
 

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -122,8 +122,7 @@ impl<R: Resource + Serialize + DeserializeOwned> PersistentBuilder<R> {
                     panic!(
                         "persistent resource path should start with \
                         \"local\" or \"session\" and be UTF-8 encoded \
-                        in WebAssembly but it's {:?}",
-                        path,
+                        in WebAssembly but it's {path:?}",
                     );
                 }
             }

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -269,9 +269,9 @@ impl Display for Storage {
             #[cfg(not(target_family = "wasm"))]
             Storage::Filesystem { path } => {
                 if let Some(path) = path.to_str() {
-                    write!(f, "{}", path)
+                    write!(f, "{path}")
                 } else {
-                    write!(f, "{:?}", path)
+                    write!(f, "{path:?}")
                 }
             },
             #[cfg(target_family = "wasm")]

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -277,12 +277,12 @@ impl Display for Storage {
             #[cfg(target_family = "wasm")]
             Storage::LocalStorage { key } => {
                 let separator = std::path::MAIN_SEPARATOR;
-                write!(f, "{}local{}{}", separator, separator, key)
+                write!(f, "{separator}local{separator}{key}")
             },
             #[cfg(target_family = "wasm")]
             Storage::SessionStorage { key } => {
                 let separator = std::path::MAIN_SEPARATOR;
-                write!(f, "{}session{}{}", separator, separator, key)
+                write!(f, "{separator}session{separator}{key}")
             },
         }
     }

--- a/tests/builder.rs
+++ b/tests/builder.rs
@@ -149,9 +149,10 @@ mod wasm {
 
         assert_eq!(resource.name(), name);
         assert_eq!(resource.format(), format);
-        assert_eq!(resource.storage(), &Storage::LocalStorage {
-            key: "key-bindings.toml".to_owned()
-        },);
+        assert_eq!(
+            resource.storage(),
+            &Storage::LocalStorage { key: "key-bindings.toml".to_owned() },
+        );
         assert_eq!(resource.get(), &default);
 
         Ok(())
@@ -181,9 +182,10 @@ mod wasm {
 
         assert_eq!(resource.name(), name);
         assert_eq!(resource.format(), format);
-        assert_eq!(resource.storage(), &Storage::LocalStorage {
-            key: "key-bindings.toml".to_owned()
-        },);
+        assert_eq!(
+            resource.storage(),
+            &Storage::LocalStorage { key: "key-bindings.toml".to_owned() },
+        );
 
         assert!(!resource.is_loaded());
         assert!(resource.is_unloaded());
@@ -227,9 +229,10 @@ mod wasm {
 
         assert_eq!(resource.name(), name);
         assert_eq!(resource.format(), format);
-        assert_eq!(resource.storage(), &Storage::SessionStorage {
-            key: "key-bindings.toml".to_owned()
-        },);
+        assert_eq!(
+            resource.storage(),
+            &Storage::SessionStorage { key: "key-bindings.toml".to_owned() },
+        );
         assert_eq!(resource.get(), &default);
 
         Ok(())
@@ -259,9 +262,10 @@ mod wasm {
 
         assert_eq!(resource.name(), name);
         assert_eq!(resource.format(), format);
-        assert_eq!(resource.storage(), &Storage::SessionStorage {
-            key: "key-bindings.toml".to_owned()
-        },);
+        assert_eq!(
+            resource.storage(),
+            &Storage::SessionStorage { key: "key-bindings.toml".to_owned() },
+        );
 
         assert!(!resource.is_loaded());
         assert!(resource.is_unloaded());

--- a/tests/storage.rs
+++ b/tests/storage.rs
@@ -48,7 +48,7 @@ mod native {
         let path = tempdir.path().join("key-bindings.toml");
         let storage = Storage::Filesystem { path: path.clone() };
 
-        assert_eq!(format!("{}", storage), format!("{}", path.to_str().unwrap()));
+        assert_eq!(format!("{storage}"), format!("{}", path.to_str().unwrap()));
 
         Ok(())
     }


### PR DESCRIPTION
Draft until the full release drops. Bump bevy to 0.16.0[-rc.4].

With `no_std` support, disabling default features now means we need to re-enable `std` to be able to compile again. Could be that another set of features would work better, but I've not checked.

No major changes besides that. `.single` now returns a result, so I switched the window example to use `Single<T>` instead of `Query<T>` for windows to not have to deal with that.